### PR TITLE
Upgrade assertj-core and add InstanceOfAssertFactories for Neo4j

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig: https://editorconfig.org/
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# 2 space indentation for java, xml and yml files
+[*.{java,xml,yml,sh}]
+indent_style = space
+indent_size = 2

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.12.2</version>
+      <version>3.13.2</version>
     </dependency>
     <dependency>
       <groupId>org.neo4j</groupId>

--- a/src/main/java/org/assertj/neo4j/api/Assertions.java
+++ b/src/main/java/org/assertj/neo4j/api/Assertions.java
@@ -26,11 +26,10 @@ import org.neo4j.graphdb.schema.IndexDefinition;
  * @author Joel Costigliola
  * @author Florent Biville
  */
-public class Assertions {
+public class Assertions implements InstanceOfAssertFactories {
 
-  @SuppressWarnings("unchecked")
-  public static PropertyContainerAssert assertThat(PropertyContainer propertyContainer) {
-    return new PropertyContainerAssert(propertyContainer, PropertyContainerAssert.class);
+  public static <T extends PropertyContainer> PropertyContainerAssert<?, T> assertThat(T propertyContainer) {
+    return new PropertyContainerAssert<>(propertyContainer, PropertyContainerAssert.class);
   }
 
   public static NodeAssert assertThat(Node node) {

--- a/src/main/java/org/assertj/neo4j/api/InstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/neo4j/api/InstanceOfAssertFactories.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2013-2017 the original author or authors.
+ */
+package org.assertj.neo4j.api;
+
+import org.assertj.core.api.Assert;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+import org.neo4j.graphdb.schema.IndexDefinition;
+
+/**
+ * Neo4j {@link InstanceOfAssertFactory InstanceOfAssertFactories} for {@link Assert#asInstanceOf(InstanceOfAssertFactory)}.
+ *
+ * @author Stefano Cordio
+ * @since 2.0.2
+ */
+public interface InstanceOfAssertFactories {
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link PropertyContainer}.
+   *
+   * @param <T>                   the {@code PropertyContainer} type.
+   * @param propertyContainerType the property container type instance.
+   * @return the factory instance.
+   */
+  static <T extends PropertyContainer> InstanceOfAssertFactory<T, PropertyContainerAssert<?, T>> propertyContainer(Class<T> propertyContainerType) {
+    return new InstanceOfAssertFactory<>(propertyContainerType, Assertions::assertThat);
+  }
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link Node}.
+   */
+  InstanceOfAssertFactory<Node, NodeAssert> NODE = new InstanceOfAssertFactory<>(Node.class, Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link Relationship}.
+   */
+  InstanceOfAssertFactory<Relationship, RelationshipAssert> RELATIONSHIP = new InstanceOfAssertFactory<>(Relationship.class,
+                                                                                                         Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link Path}.
+   */
+  InstanceOfAssertFactory<Path, PathAssert> PATH = new InstanceOfAssertFactory<>(Path.class, Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link Result}.
+   */
+  InstanceOfAssertFactory<Result, ResultAssert> RESULT = new InstanceOfAssertFactory<>(Result.class, Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link ConstraintDefinition}.
+   */
+  InstanceOfAssertFactory<ConstraintDefinition, ConstraintDefinitionAssert> CONSTRAINT_DEFINITION = new InstanceOfAssertFactory<>(ConstraintDefinition.class,
+                                                                                                                                  Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for an {@link IndexDefinition}.
+   */
+  InstanceOfAssertFactory<IndexDefinition, IndexDefinitionAssert> INDEX_DEFINITION = new InstanceOfAssertFactory<>(IndexDefinition.class,
+                                                                                                                   Assertions::assertThat);
+
+}

--- a/src/test/java/org/assertj/neo4j/api/InstanceOfAssertFactoriesTest.java
+++ b/src/test/java/org/assertj/neo4j/api/InstanceOfAssertFactoriesTest.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2013-2017 the original author or authors.
+ */
+package org.assertj.neo4j.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.neo4j.api.InstanceOfAssertFactories.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+import org.neo4j.graphdb.schema.IndexDefinition;
+
+/**
+ * @author Stefano Cordio
+ * @since 2.0.2
+ */
+public class InstanceOfAssertFactoriesTest {
+
+  @Test
+  public void property_container_factory_should_allow_property_container_assertions() {
+    // GIVEN
+    Object value = mock(PropertyContainer.class);
+    // WHEN
+    PropertyContainerAssert<?, PropertyContainer> result = assertThat(value).asInstanceOf(propertyContainer(PropertyContainer.class));
+    // THEN
+    result.doesNotHavePropertyKey("key");
+  }
+
+  @Test
+  public void node_factory_should_allow_node_assertions() {
+    // GIVEN
+    Object value = mock(Node.class);
+    // WHEN
+    NodeAssert result = assertThat(value).asInstanceOf(NODE);
+    // THEN
+    result.doesNotHaveLabel(Label.label("label"));
+  }
+
+  @Test
+  public void relationship_factory_should_allow_relationship_assertions() {
+    // GIVEN
+    Object value = mock(Relationship.class, RETURNS_MOCKS);
+    // WHEN
+    RelationshipAssert result = assertThat(value).asInstanceOf(RELATIONSHIP);
+    // THEN
+    result.doesNotHaveType("type");
+  }
+
+  @Test
+  public void path_factory_should_allow_path_assertions() {
+    // GIVEN
+    Object value = mock(Path.class);
+    // WHEN
+    PathAssert result = assertThat(value).asInstanceOf(PATH);
+    // THEN
+    result.hasLength(0);
+  }
+
+  @Test
+  public void result_factory_should_allow_result_assertions() {
+    // GIVEN
+    Object value = mock(Result.class);
+    // WHEN
+    ResultAssert result = assertThat(value).asInstanceOf(RESULT);
+    // THEN
+    result.isEmpty();
+  }
+
+  @SuppressWarnings("CastCanBeRemovedNarrowingVariableType")
+  @Test
+  public void constraint_definition_factory_should_allow_constraint_definition_assertions() {
+    // GIVEN
+    Object value = mock(ConstraintDefinition.class, RETURNS_DEEP_STUBS);
+    given(((ConstraintDefinition) value).getLabel().name()).willReturn("label");
+    // WHEN
+    ConstraintDefinitionAssert result = assertThat(value).asInstanceOf(CONSTRAINT_DEFINITION);
+    // THEN
+    result.hasLabel("label");
+  }
+
+  @Test
+  public void index_definition_factory_should_allow_index_definition_assertions() {
+    // GIVEN
+    Object value = mock(IndexDefinition.class, RETURNS_MOCKS);
+    // WHEN
+    IndexDefinitionAssert result = assertThat(value).asInstanceOf(INDEX_DEFINITION);
+    // THEN
+    result.doesNotHaveLabel("label");
+  }
+
+}


### PR DESCRIPTION
This PR introduces `InstanceOfAssertFactories` for Neo4j, following joel-costigliola/assertj-core#1498.

~`assertj-core` 3.13.2 should be released in few days, I'll update this PR once it is available.~

`assertj-core` has been upgraded to 3.13.2.

Please check #31 first as it should fix the build issue.