### PR TITLE
Update parent pom version and Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,16 @@ language: java
 install:
   - mvn -q install -DskipTests=true -B -V
 script: mvn clean verify -B -V
+
 jdk:
-   - oraclejdk8
+  - openjdk11
+  - openjdk12
+  - openjdk13
+  - openjdk-ea
+
+matrix:
+  allow_failures:
+    - jdk: openjdk-ea
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.assertj</groupId>
     <artifactId>assertj-parent-pom</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.5</version>
   </parent>
 
   <scm>
@@ -57,40 +57,15 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.mycila.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
-        <version>1.9.0</version>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
         <configuration>
-          <!-- Template location -->
-          <header>licence-header.txt</header>
           <properties>
-            <!-- Values to be substituted in template -->
             <inceptionYear>2013</inceptionYear>
-            <currentYear>2017</currentYear>
           </properties>
-          <strictCheck>true</strictCheck>
-          <includes>
-            <include>src/**</include>
-          </includes>
         </configuration>
-        <executions>
-          <execution>
-            <phase>validate</phase>
-            <goals>
-              <goal>format</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.7.1</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 
   <reporting>
@@ -98,7 +73,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.0.0</version>
       </plugin>
     </plugins>
   </reporting>
@@ -115,38 +89,14 @@
       <build>
         <plugins>
           <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>@{argLine}</argLine>
-            </configuration>
-          </plugin>
-          <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.7.9</version>
-            <executions>
-              <execution>
-                <id>agent</id>
-                <goals>
-                  <goal>prepare-agent</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>report</id>
-                <phase>test</phase>
-                <goals>
-                  <goal>report</goal>
-                </goals>
-              </execution>
-            </executions>
           </plugin>
+          <!-- to get jacoco report we need to set argLine in surefire, without this snippet the jacoco argLine is lost -->
           <plugin>
-            <groupId>com.mycila</groupId>
-            <artifactId>license-maven-plugin</artifactId>
+            <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <properties>
-                <inceptionYear>2013</inceptionYear>
-              </properties>
+              <argLine>${argLine}</argLine>
             </configuration>
           </plugin>
         </plugins>

--- a/src/main/java/org/assertj/neo4j/api/Assertions.java
+++ b/src/main/java/org/assertj/neo4j/api/Assertions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/main/java/org/assertj/neo4j/api/ConstraintDefinitionAssert.java
+++ b/src/main/java/org/assertj/neo4j/api/ConstraintDefinitionAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/main/java/org/assertj/neo4j/api/IndexDefinitionAssert.java
+++ b/src/main/java/org/assertj/neo4j/api/IndexDefinitionAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/main/java/org/assertj/neo4j/api/NodeAssert.java
+++ b/src/main/java/org/assertj/neo4j/api/NodeAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/main/java/org/assertj/neo4j/api/PathAssert.java
+++ b/src/main/java/org/assertj/neo4j/api/PathAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/main/java/org/assertj/neo4j/api/PropertyContainerAssert.java
+++ b/src/main/java/org/assertj/neo4j/api/PropertyContainerAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/main/java/org/assertj/neo4j/api/RelationshipAssert.java
+++ b/src/main/java/org/assertj/neo4j/api/RelationshipAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/main/java/org/assertj/neo4j/api/ResultAssert.java
+++ b/src/main/java/org/assertj/neo4j/api/ResultAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldEndWithNode.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldEndWithNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldEndWithRelationship.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldEndWithRelationship.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldHaveLabel.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldHaveLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldHaveLength.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldHaveLength.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldHaveProperty.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldHaveProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldHavePropertyKey.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldHavePropertyKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldHaveRelationshipType.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldHaveRelationshipType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldNotEndWithNode.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldNotEndWithNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldNotEndWithRelationship.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldNotEndWithRelationship.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldNotHaveLabel.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldNotHaveLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldNotHaveProperty.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldNotHaveProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldNotHavePropertyKey.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldNotHavePropertyKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldNotHaveRelationshipType.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldNotHaveRelationshipType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldNotStartWithNode.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldNotStartWithNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldStartOrEndWithNode.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldStartOrEndWithNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldStartWithNode.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldStartWithNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.error;
 

--- a/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_ConstraintDefinition_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_ConstraintDefinition_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_IndexDefinition_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_IndexDefinition_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_Node_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_Node_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_Path_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_Path_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_PropertyContainer_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_PropertyContainer_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_Relationship_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_Relationship_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_Result_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/Assertions_assertThat_with_Result_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api;
 

--- a/src/test/java/org/assertj/neo4j/api/constraintedefinition/ConstraintDefinitionAssert_hasLabel_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/constraintedefinition/ConstraintDefinitionAssert_hasLabel_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.constraintedefinition;
 

--- a/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_doesNotHaveLabel_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_doesNotHaveLabel_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.indexdefinition;
 

--- a/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_doesNotHaveLabel_represented_as_string_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_doesNotHaveLabel_represented_as_string_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.indexdefinition;
 

--- a/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_hasLabel_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_hasLabel_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.indexdefinition;
 

--- a/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_hasLabel_represented_as_string_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_hasLabel_represented_as_string_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.indexdefinition;
 

--- a/src/test/java/org/assertj/neo4j/api/node/NodeAssert_doesNotHaveLabel_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/node/NodeAssert_doesNotHaveLabel_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.node;
 

--- a/src/test/java/org/assertj/neo4j/api/node/NodeAssert_doesNotHaveLabel_represented_as_string_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/node/NodeAssert_doesNotHaveLabel_represented_as_string_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.node;
 

--- a/src/test/java/org/assertj/neo4j/api/node/NodeAssert_hasLabel_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/node/NodeAssert_hasLabel_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.node;
 

--- a/src/test/java/org/assertj/neo4j/api/node/NodeAssert_hasLabel_represented_as_string_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/node/NodeAssert_hasLabel_represented_as_string_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.node;
 

--- a/src/test/java/org/assertj/neo4j/api/path/PathAssert_doesNotEndWithNode_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/path/PathAssert_doesNotEndWithNode_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.path;
 

--- a/src/test/java/org/assertj/neo4j/api/path/PathAssert_doesNotEndWithRelationship_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/path/PathAssert_doesNotEndWithRelationship_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.path;
 

--- a/src/test/java/org/assertj/neo4j/api/path/PathAssert_doesNotStartWithNode_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/path/PathAssert_doesNotStartWithNode_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.path;
 

--- a/src/test/java/org/assertj/neo4j/api/path/PathAssert_endsWithNode_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/path/PathAssert_endsWithNode_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.path;
 

--- a/src/test/java/org/assertj/neo4j/api/path/PathAssert_endsWithRelationship_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/path/PathAssert_endsWithRelationship_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.path;
 

--- a/src/test/java/org/assertj/neo4j/api/path/PathAssert_hasLength_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/path/PathAssert_hasLength_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.path;
 

--- a/src/test/java/org/assertj/neo4j/api/path/PathAssert_startsWithNode_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/path/PathAssert_startsWithNode_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.path;
 

--- a/src/test/java/org/assertj/neo4j/api/propertycontainer/PropertyContainerAssert_doesNotHavePropertyKey_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/propertycontainer/PropertyContainerAssert_doesNotHavePropertyKey_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.propertycontainer;
 

--- a/src/test/java/org/assertj/neo4j/api/propertycontainer/PropertyContainerAssert_doesNotHaveProperty_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/propertycontainer/PropertyContainerAssert_doesNotHaveProperty_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.propertycontainer;
 

--- a/src/test/java/org/assertj/neo4j/api/propertycontainer/PropertyContainerAssert_hasPropertyKey_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/propertycontainer/PropertyContainerAssert_hasPropertyKey_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.propertycontainer;
 

--- a/src/test/java/org/assertj/neo4j/api/propertycontainer/PropertyContainerAssert_hasProperty_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/propertycontainer/PropertyContainerAssert_hasProperty_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.propertycontainer;
 

--- a/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_doesNotEndWithNode_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_doesNotEndWithNode_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.relationship;
 

--- a/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_doesNotHaveType_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_doesNotHaveType_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.relationship;
 

--- a/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_doesNotHaveType_represented_as_string_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_doesNotHaveType_represented_as_string_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.relationship;
 

--- a/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_doesNotStartWithNode_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_doesNotStartWithNode_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.relationship;
 

--- a/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_endsWithNode_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_endsWithNode_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.relationship;
 

--- a/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_hasType_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_hasType_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.relationship;
 

--- a/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_hasType_represented_as_string_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_hasType_represented_as_string_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.relationship;
 

--- a/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_startsOrEndsWithNode_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_startsOrEndsWithNode_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.relationship;
 

--- a/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_startsWithNode_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/relationship/RelationshipAssert_startsWithNode_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.relationship;
 

--- a/src/test/java/org/assertj/neo4j/api/result/ResultAssert_contains_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/result/ResultAssert_contains_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.result;
 

--- a/src/test/java/org/assertj/neo4j/api/result/TestResult.java
+++ b/src/test/java/org/assertj/neo4j/api/result/TestResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -8,7 +8,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  */
 package org.assertj.neo4j.api.result;
 


### PR DESCRIPTION
This PR:
* should fix the recent build issue, updating Travis configuration as Oracle JDK 8 is not supported anymore and removing the JaCoCo configuration which is already provided by the parent pom
* should fix the issue on joel-costigliola/assertj-maven-parent-pom#38
* simplifies the license plugin configuration which is already provided by the parent pom