### PR TITLE
Provide assertions for ConstraintDefinition(relationshipType) #34

### DIFF
--- a/src/main/java/org/assertj/neo4j/api/ConstraintDefinitionAssert.java
+++ b/src/main/java/org/assertj/neo4j/api/ConstraintDefinitionAssert.java
@@ -12,14 +12,17 @@
  */
 package org.assertj.neo4j.api;
 
+import static org.assertj.neo4j.error.ShouldHaveLabel.shouldHaveLabel;
+import static org.assertj.neo4j.error.ShouldNotHaveLabel.shouldNotHaveLabel;
+
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.Objects;
+import org.assertj.neo4j.error.ShouldHaveRelationshipType;
+import org.assertj.neo4j.error.ShouldNotHaveRelationshipType;
 import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
-
-import static org.assertj.neo4j.error.ShouldHaveLabel.shouldHaveLabel;
-import static org.assertj.neo4j.error.ShouldNotHaveLabel.shouldNotHaveLabel;
 
 /**
  * Assertions for Neo4J {@link ConstraintDefinition}
@@ -187,4 +190,102 @@ public class ConstraintDefinitionAssert extends AbstractAssert<ConstraintDefinit
     }
     return this;
   }
+  
+  /**
+   * Verifies that the actual {@link ConstraintDefinition} has the given relationship type<br/>
+   * <p>
+   * If the <code>relationshipType</code> is {@code null}, an {@link IllegalArgumentException} is thrown.
+   * <p>
+   *
+   * @param relationshipType the relationship type to look for in the actual {@link ConstraintDefinition}
+   * @return this {@link ConstraintDefinitionAssert} for assertions chaining
+   *
+   * @throws IllegalArgumentException if <code>relationshipType</code> is {@code null}.
+   * @throws AssertionError if the actual {@link ConstraintDefinition} does not contain the given relationshipType
+   */
+  public ConstraintDefinitionAssert hasRelationshipType(RelationshipType relationshipType){
+	  Objects.instance().assertNotNull(info, actual);
+	  
+	  if (relationshipType == null){
+		  throw new IllegalArgumentException("The relationship type to look for should not be null");
+	  }
+	  if (!actual.getRelationshipType().equals(relationshipType)) {
+		  throw Failures.instance().failure(info, ShouldHaveRelationshipType.shouldHaveRelationshipType(actual.getRelationshipType(), relationshipType.name()));
+	  }
+	  return this;
+  }
+  
+  /**
+   * Verifies that the actual {@link ConstraintDefinition} does not have the given relationship type<br/>
+   * <p>
+   * If the <code>relationshipType</code> is {@code null}, an {@link IllegalArgumentException} is thrown.
+   * <p>
+   *
+   * @param relationshipType the relationship type to look for in the actual {@link ConstraintDefinition}
+   * @return this {@link ConstraintDefinitionAssert} for assertions chaining
+   *
+   * @throws IllegalArgumentException if <code>relationshipType</code> is {@code null}.
+   * @throws AssertionError if the actual {@link ConstraintDefinition} contains the given relationshipType
+   */
+  public ConstraintDefinitionAssert doesNotHaveRelationshipType(RelationshipType relationshipType){
+	  Objects.instance().assertNotNull(info, actual);
+	  
+	  if (relationshipType == null){
+		  throw new IllegalArgumentException("The relationship type to look for should not be null");
+	  }
+	  if (actual.getRelationshipType().equals(relationshipType)) {
+		  throw Failures.instance().failure(info, ShouldNotHaveRelationshipType.shouldNotHaveRelationshipType(actual.getRelationshipType(), relationshipType.name()));
+	  }
+	  return this;
+  }
+  
+  /**
+   * Verifies that the actual {@link ConstraintDefinition} has the given relationship type name<br/>
+   * <p>
+   * If the <code>relationshipTypeName</code> is {@code null}, an {@link IllegalArgumentException} is thrown.
+   * <p>
+   *
+   * @param relationshipTypeName the relationship type name to look for in the actual {@link ConstraintDefinition}
+   * @return this {@link ConstraintDefinitionAssert} for assertions chaining
+   *
+   * @throws IllegalArgumentException if <code>relationshipTypeName</code> is {@code null}.
+   * @throws AssertionError if the actual {@link ConstraintDefinition} does not contain the given relationshipType name
+   */
+  public ConstraintDefinitionAssert hasRelationshipType(String relationshipTypeName){
+	  Objects.instance().assertNotNull(info, actual);
+	  
+	  if (relationshipTypeName == null){
+		  throw new IllegalArgumentException("The relationship type name to look for should not be null");
+	  }
+	  if (!actual.getRelationshipType().name().equals(relationshipTypeName)) {
+		  throw Failures.instance().failure(info, ShouldHaveRelationshipType.shouldHaveRelationshipType(actual.getRelationshipType(), relationshipTypeName));
+	  }
+	  return this;
+  }
+  
+  /**
+   * Verifies that the actual {@link ConstraintDefinition} does not have the given relationship type name<br/>
+   * <p>
+   * If the <code>relationshipTypeName</code> is {@code null}, an {@link IllegalArgumentException} is thrown.
+   * <p>
+   *
+   * @param relationshipTypeName the relationship type name to look for in the actual {@link ConstraintDefinition}
+   * @return this {@link ConstraintDefinitionAssert} for assertions chaining
+   *
+   * @throws IllegalArgumentException if <code>relationshipTypeName</code> is {@code null}.
+   * @throws AssertionError if the actual {@link ConstraintDefinition} contains the given relationshipType name
+   */
+  public ConstraintDefinitionAssert doesNotHaveRelationshipType(String relationshipTypeName){
+	  Objects.instance().assertNotNull(info, actual);
+	  
+	  if (relationshipTypeName == null){
+		  throw new IllegalArgumentException("The relationship type name to look for should not be null");
+	  }
+	  if (actual.getRelationshipType().name().equals(relationshipTypeName)) {
+		  throw Failures.instance().failure(info, ShouldNotHaveRelationshipType.shouldNotHaveRelationshipType(actual.getRelationshipType(), relationshipTypeName));
+	  }
+	  return this;
+  }
+  
+  
 }

--- a/src/main/java/org/assertj/neo4j/error/ShouldHaveRelationshipType.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldHaveRelationshipType.java
@@ -15,7 +15,6 @@ package org.assertj.neo4j.error;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 import org.assertj.core.internal.StandardComparisonStrategy;
-import org.neo4j.graphdb.Relationship;
 
 public class ShouldHaveRelationshipType extends BasicErrorMessageFactory {
 
@@ -27,12 +26,12 @@ public class ShouldHaveRelationshipType extends BasicErrorMessageFactory {
    *          relationship type name to.
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldHaveRelationshipType(Relationship actual, String relationshipTypeName) {
+  public static ErrorMessageFactory shouldHaveRelationshipType(Object actual, String relationshipTypeName) {
     return new ShouldHaveRelationshipType(actual, relationshipTypeName);
   }
 
-  private ShouldHaveRelationshipType(Relationship actual, String other) {
-    super("\nExpecting:\n  <%s>\nto have type:\n  <%s>\n%s", actual, other, StandardComparisonStrategy.instance());
+  private ShouldHaveRelationshipType(Object actual, String other) {
+    super("\nExpecting:\n  <%s>\nto have relationship type:\n  <%s>\n%s", actual, other, StandardComparisonStrategy.instance());
   }
 
 }

--- a/src/main/java/org/assertj/neo4j/error/ShouldNotHaveRelationshipType.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldNotHaveRelationshipType.java
@@ -15,7 +15,6 @@ package org.assertj.neo4j.error;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 import org.assertj.core.internal.StandardComparisonStrategy;
-import org.neo4j.graphdb.Relationship;
 
 public class ShouldNotHaveRelationshipType extends BasicErrorMessageFactory {
 
@@ -27,11 +26,11 @@ public class ShouldNotHaveRelationshipType extends BasicErrorMessageFactory {
    *          type name to.
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldNotHaveRelationshipType(Relationship actual, String relationshipType) {
+  public static ErrorMessageFactory shouldNotHaveRelationshipType(Object actual, String relationshipType) {
     return new ShouldNotHaveRelationshipType(actual, relationshipType);
   }
 
-  private ShouldNotHaveRelationshipType(Relationship actual, String other) {
-    super("\nExpecting:\n  <%s>\nnot to have type:\n  <%s>\n%s", actual, other, StandardComparisonStrategy.instance());
+  private ShouldNotHaveRelationshipType(Object actual, String other) {
+    super("\nExpecting:\n  <%s>\nnot to have relationship type:\n  <%s>\n%s", actual, other, StandardComparisonStrategy.instance());
   }
 }

--- a/src/test/java/org/assertj/neo4j/api/constraintedefinition/ConstraintDefinitionAssert_doesNotHaveRelationshipType_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/constraintedefinition/ConstraintDefinitionAssert_doesNotHaveRelationshipType_Test.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2013-2019 the original author or authors.
+ */
+package org.assertj.neo4j.api.constraintedefinition;
+
+import static org.assertj.neo4j.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+
+public class ConstraintDefinitionAssert_doesNotHaveRelationshipType_Test {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private ConstraintDefinition constraintDefinition = mock(ConstraintDefinition.class);
+
+  @Test
+  public void should_pass_if_constraint_definition_does_not_have_relationship_type() {
+    when(constraintDefinition.getRelationshipType()).thenReturn(RelationshipType.withName("Foo"));
+
+    assertNotNull(assertThat(constraintDefinition).doesNotHaveRelationshipType(RelationshipType.withName("Bar")));
+  }
+
+  @Test
+  public void should_fail_if_constraint_definition_have_given_relationshiptype() {
+    when(constraintDefinition.getRelationshipType()).thenReturn(RelationshipType.withName("Foo"));
+    expectedException.expect(AssertionError.class);
+
+    assertThat(constraintDefinition).doesNotHaveRelationshipType(RelationshipType.withName("Foo"));
+  }
+
+  @Test
+  public void should_fail_if_relationshiptype_is_null() {
+    when(constraintDefinition.getRelationshipType()).thenReturn(RelationshipType.withName("Foo"));
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("The relationship type to look for should not be null");
+
+    assertThat(constraintDefinition).doesNotHaveRelationshipType((RelationshipType) null);
+  }
+
+  @Test
+  public void should_fail_constraint_definition_is_null() {
+    expectedException.expect(AssertionError.class);
+    expectedException.expectMessage("Expecting actual not to be null");
+
+    assertThat((ConstraintDefinition) null).doesNotHaveRelationshipType(RelationshipType.withName("Foo"));
+  }
+
+  @Test
+  public void should_pass_if_constraint_definition_does_not_have_relationshiptype_with_name() {
+    when(constraintDefinition.getRelationshipType()).thenReturn(RelationshipType.withName("Foo"));
+
+    assertNotNull(assertThat(constraintDefinition).doesNotHaveRelationshipType("Bar"));
+  }
+
+  @Test
+  public void should_fail_if_consrtraint_definition_has_relationshiptype_with_name() {
+    when(constraintDefinition.getRelationshipType()).thenReturn(RelationshipType.withName("Foo"));
+    expectedException.expect(AssertionError.class);
+
+    assertThat(constraintDefinition).doesNotHaveRelationshipType("Foo");
+  }
+
+  @Test
+  public void should_fail_if_relationshiptype_name_is_null() {
+    when(constraintDefinition.getRelationshipType()).thenReturn(RelationshipType.withName("Foo"));
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("The relationship type name to look for should not be null");
+
+    assertThat(constraintDefinition).doesNotHaveRelationshipType((String) null);
+  }
+
+  @Test
+  public void should_fail_constraint_definition_is_null_with_relationshiptype_name() {
+    expectedException.expect(AssertionError.class);
+    expectedException.expectMessage("Expecting actual not to be null");
+
+    assertThat((ConstraintDefinition) null).doesNotHaveRelationshipType("B");
+  }
+  
+}

--- a/src/test/java/org/assertj/neo4j/api/constraintedefinition/ConstraintDefinitionAssert_hasRelationshipType_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/constraintedefinition/ConstraintDefinitionAssert_hasRelationshipType_Test.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2013-2019 the original author or authors.
+ */
+package org.assertj.neo4j.api.constraintedefinition;
+
+import static org.assertj.neo4j.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+
+public class ConstraintDefinitionAssert_hasRelationshipType_Test {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private ConstraintDefinition constraintDefinition = mock(ConstraintDefinition.class);
+
+  @Test
+  public void should_pass_if_constraint_definition_has_relationship_type() {
+    when(constraintDefinition.getRelationshipType()).thenReturn(RelationshipType.withName("Foo"));
+
+    assertNotNull(assertThat(constraintDefinition).hasRelationshipType(RelationshipType.withName("Foo")));
+  }
+
+  @Test
+  public void should_fail_if_constraint_definition_does_not_have_expected_relationshiptype() {
+    when(constraintDefinition.getRelationshipType()).thenReturn(RelationshipType.withName("Foo"));
+    expectedException.expect(AssertionError.class);
+
+    assertThat(constraintDefinition).hasRelationshipType(RelationshipType.withName("Bar"));
+  }
+
+  @Test
+  public void should_fail_if_relationshiptype_is_null() {
+    when(constraintDefinition.getRelationshipType()).thenReturn(RelationshipType.withName("Foo"));
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("The relationship type to look for should not be null");
+
+    assertThat(constraintDefinition).hasRelationshipType((RelationshipType) null);
+  }
+
+  @Test
+  public void should_fail_constraint_definition_is_null() {
+    expectedException.expect(AssertionError.class);
+    expectedException.expectMessage("Expecting actual not to be null");
+
+    assertThat((ConstraintDefinition) null).hasRelationshipType(RelationshipType.withName("Bar"));
+  }
+
+  @Test
+  public void should_pass_if_constraint_definition_has_relationshiptype_with_name() {
+    when(constraintDefinition.getRelationshipType()).thenReturn(RelationshipType.withName("Foo"));
+
+    assertNotNull(assertThat(constraintDefinition).hasRelationshipType("Foo"));
+  }
+
+  @Test
+  public void should_fail_if_consrtraint_definition_does_not_have_expected_relationshiptype_with_name() {
+    when(constraintDefinition.getRelationshipType()).thenReturn(RelationshipType.withName("Foo"));
+    expectedException.expect(AssertionError.class);
+
+    assertThat(constraintDefinition).hasRelationshipType("Bar");
+  }
+
+  @Test
+  public void should_fail_if_relationshiptype_name_is_null() {
+    when(constraintDefinition.getRelationshipType()).thenReturn(RelationshipType.withName("Foo"));
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("The relationship type name to look for should not be null");
+
+    assertThat(constraintDefinition).hasRelationshipType((String) null);
+  }
+
+  @Test
+  public void should_fail_constraint_definition_is_null_with_relationshiptype_name() {
+    expectedException.expect(AssertionError.class);
+    expectedException.expectMessage("Expecting actual not to be null");
+
+    assertThat((ConstraintDefinition) null).hasRelationshipType("Bar");
+  }
+  
+}


### PR DESCRIPTION
Added methods in ConstraintDefinitionAssert class:
-> hasRelationshipType for RelationshipType
-> hasRelationshipType for String
-> doesNotHaveRelationshipType for RelationshipType
-> doesNotHaveRelationshipType for String