### PR TITLE
Provide assertions for IndexDefinition(propertyKeys)

### DIFF
--- a/src/main/java/org/assertj/neo4j/api/IndexDefinitionAssert.java
+++ b/src/main/java/org/assertj/neo4j/api/IndexDefinitionAssert.java
@@ -20,6 +20,13 @@ import org.neo4j.graphdb.schema.IndexDefinition;
 
 import static org.assertj.neo4j.error.ShouldHaveLabel.shouldHaveLabel;
 import static org.assertj.neo4j.error.ShouldNotHaveLabel.shouldNotHaveLabel;
+import static org.assertj.neo4j.error.ShouldHavePropertyKeys.shouldHavePropertyKeys;
+import static org.assertj.neo4j.error.ShouldNotHavePropertyKeys.shouldNotHavePropertyKeys;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.StreamSupport;
 
 /**
  * Assertions for Neo4J {@link IndexDefinition}
@@ -181,6 +188,182 @@ public class IndexDefinitionAssert extends AbstractAssert<IndexDefinitionAssert,
     }
     return this;
   }
+  
 
+  /**
+   * Verifies that the actual {@link IndexDefinition} has the given set of property keys<br/>
+   * <p>
+   * Example:
+   *
+   * <pre>
+   * GraphDatabaseService graph = new TestGraphDatabaseFactory().newImpermanentDatabase();
+   * IndexDefinition indexDefinition = graph.schema()
+   *    .indexFor(Label.label(&quot;Spiderman&quot;))
+   *    .on(&quot;name&quot;,&quot;power&quot).create();
+   *
+   * Collection<String> keys=new ArrayList<>();
+   * keys.add(&quot;name&quot;);
+   * keys.add(&quot;power&quot;);
+   * assertThat(indexDefinition).hasPropertyKeys(keys);
+   * </pre>
+   *
+   * If the <code>propertyKeys</code> is {@code null}, an {@link IllegalArgumentException} is thrown.
+   * <p>
+   *
+   * @param propertyKeys the list of property keys to look for in the actual {@link IndexDefinition}
+   * @return this {@link IndexDefinitionAssert} for assertions chaining
+   *
+   * @throws IllegalArgumentException if <code>propertyKeys</code> is {@code null}.
+   * @throws AssertionError if the actual {@link IndexDefinition} does not contain the given propertyKeys
+   */
+  public IndexDefinitionAssert hasPropertyKeys(Iterable<String> propertyKeys) {
+	  Objects.instance().assertNotNull(info, actual);
+	  
+	  if (propertyKeys == null) {
+	      throw new IllegalArgumentException("The property keys to look for should not be null");
+	  }
+	  boolean st=StreamSupport.stream(propertyKeys.spliterator(), true)
+			  .allMatch(p->isContains(actual.getPropertyKeys(),p));
+	  
+	  if (!st) {
+	      throw Failures.instance().failure(info, shouldHavePropertyKeys(actual, propertyKeys));
+	   }
+	 
+	  return this; 
+  }
+  
+  /**
+   * Verifies that the actual {@link IndexDefinition} has the given set of names of property keys<br/>
+   * <p>
+   * Example:
+   *
+   * <pre>
+   * GraphDatabaseService graph = new TestGraphDatabaseFactory().newImpermanentDatabase();
+   * IndexDefinition indexDefinition = graph.schema()
+   *    .indexFor(Label.label(&quot;Spiderman&quot;))
+   *    .on(&quot;name&quot;,&quot;power&quot).create();
+   *
+   * assertThat(indexDefinition).hasPropertyKeys(&quot;name&quot;,&quot;power&quot;);
+   * </pre>
+   *
+   * If the <code>propertyKeysNames</code> is {@code null}, an {@link IllegalArgumentException} is thrown.
+   * <p>
+   *
+   * @param propertyKeysNames the list of property keys to look for in the actual {@link IndexDefinition}
+   * @return this {@link IndexDefinitionAssert} for assertions chaining
+   *
+   * @throws IllegalArgumentException if <code>propertyKeysNames</code> is {@code null}.
+   * @throws AssertionError if the actual {@link IndexDefinition} does not contain the given propertyKeys
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public IndexDefinitionAssert hasPropertyKeys(String... propertyKeysNames) {
+	  Objects.instance().assertNotNull(info, actual);
+	 
+	  if (propertyKeysNames == null) {
+	      throw new IllegalArgumentException("The property keys names to look for should not be null");
+	  }
+	  
+	  boolean st=Arrays.stream(propertyKeysNames).allMatch(p->isContains(actual.getPropertyKeys(),p));
+	  
+	  if (!st) {
+		  Collection keys=new ArrayList<>();
+		  for(String s: propertyKeysNames) {
+			  keys.add(s);
+		  }
+	      throw Failures.instance().failure(info, shouldHavePropertyKeys(actual, keys));
+	   }
+	 
+	  return this; 
+  }
+  
+  /**
+   * Verifies that the actual {@link IndexDefinition} does NOT have the given set of property keys<br/>
+   * <p>
+   * Example:
+   *
+   * <pre>
+   * GraphDatabaseService graph = new TestGraphDatabaseFactory().newImpermanentDatabase();
+   * IndexDefinition indexDefinition = graph.schema()
+   *    .indexFor(Label.label(&quot;IronMan&quot;))
+   *    .on(&quot;name&quot;,&quot;power&quot).create();
+   *
+   * Collection<String> keys=new ArrayList<>();
+   * keys.add(&quot;height&quot;);
+   * keys.add(&quot;weight&quot;);
+   * assertThat(indexDefinition).doesNotHavePropertyKeys(keys);
+   * </pre>
+   *
+   * If the <code>propertyKeys</code> is {@code null}, an {@link IllegalArgumentException} is thrown.
+   * <p>
+   *
+   * @param propertyKeys the list of property keys to look for in the actual {@link IndexDefinition}
+   * @return this {@link IndexDefinitionAssert} for assertions chaining
+   *
+   * @throws IllegalArgumentException if <code>propertyKeys</code> is {@code null}.
+   * @throws AssertionError if the actual {@link IndexDefinition} does contain the given propertyKeys
+   */
+  public IndexDefinitionAssert doesNotHavePropertyKeys(Iterable<String> propertyKeys) {
+	  Objects.instance().assertNotNull(info, actual);
+	  if (propertyKeys == null) {
+	      throw new IllegalArgumentException("The property keys to look for should not be null");
+	  }
+	  boolean st=StreamSupport.stream(propertyKeys.spliterator(), true)
+			  .allMatch(p->isContains(actual.getPropertyKeys(),p));
+	  
+	  if (st) {
+	      throw Failures.instance().failure(info, shouldNotHavePropertyKeys(actual, propertyKeys));
+	   }
+	 
+	  return this; 
+  }
+  
+  /**
+   * Verifies that the actual {@link IndexDefinition} does NOT have the given set of names of property keys<br/>
+   * <p>
+   * Example:
+   *
+   * <pre>
+   * GraphDatabaseService graph = new TestGraphDatabaseFactory().newImpermanentDatabase();
+   * IndexDefinition indexDefinition = graph.schema()
+   *    .indexFor(Label.label(&quot;IronMan&quot;))
+   *    .on(&quot;name&quot;,&quot;power&quot).create();
+   *
+   * assertThat(indexDefinition).hasPropertyKeys(&quot;height&quot;,&quot;weight&quot;);
+   * </pre>
+   *
+   * If the <code>propertyKeysNames</code> is {@code null}, an {@link IllegalArgumentException} is thrown.
+   * <p>
+   *
+   * @param propertyKeysNames the list of property keys to look for in the actual {@link IndexDefinition}
+   * @return this {@link IndexDefinitionAssert} for assertions chaining
+   *
+   * @throws IllegalArgumentException if <code>propertyKeysNames</code> is {@code null}.
+   * @throws AssertionError if the actual {@link IndexDefinition} does contain the given propertyKeys
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public IndexDefinitionAssert doesNotHavePropertyKeys(String... propertyKeysNames) {
+	  Objects.instance().assertNotNull(info, actual);
+	  
+	  if (propertyKeysNames == null) {
+	      throw new IllegalArgumentException("The property keys names to look for should not be null");
+	  }
+	  
+	  boolean st=Arrays.stream(propertyKeysNames).allMatch(p->isContains(actual.getPropertyKeys(),p));
+	  
+	  if (st) {
+		  Collection keys=new ArrayList<>();
+		  for(String s: propertyKeysNames) {
+			  keys.add(s);
+		  }
+	      throw Failures.instance().failure(info, shouldNotHavePropertyKeys(actual, keys));
+	   }
+	 
+	  return this; 
+  }
+  
+  private boolean isContains(Iterable<String> list,String val) {
+	  return StreamSupport.stream(list.spliterator(), true).filter(o -> o.equals(val)).findFirst().isPresent();
+	  
+  }
 }
 

--- a/src/main/java/org/assertj/neo4j/error/ShouldHavePropertyKeys.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldHavePropertyKeys.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2013-2019 the original author or authors.
+ */
+package org.assertj.neo4j.error;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+import org.assertj.core.internal.StandardComparisonStrategy;
+
+
+
+public class ShouldHavePropertyKeys extends BasicErrorMessageFactory{
+	
+	  /**
+	   * Creates a new </code>{@link ShouldHavePropertyKeys}</code>.
+	   * 
+	   * @param actual the actual value in the failed assertion.
+	   * @param key the key used in the failed assertion to compare the actual property key to.
+	   * @return the created {@code ErrorMessageFactory}.
+	   */
+
+	  public static ErrorMessageFactory shouldHavePropertyKeys(Object actual, Iterable<String> key) {
+	    return new ShouldHavePropertyKeys(actual, key);
+	  }
+
+	  private ShouldHavePropertyKeys(Object actual, Iterable<String> other) {
+	    super("\nExpecting:\n  <%s>\n to have property keys:\n  <%s>\n%s", actual, other, StandardComparisonStrategy
+	        .instance());
+	  }
+
+}

--- a/src/main/java/org/assertj/neo4j/error/ShouldNotHavePropertyKeys.java
+++ b/src/main/java/org/assertj/neo4j/error/ShouldNotHavePropertyKeys.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2013-2019 the original author or authors.
+ */
+package org.assertj.neo4j.error;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+import org.assertj.core.internal.StandardComparisonStrategy;
+
+
+public class ShouldNotHavePropertyKeys extends BasicErrorMessageFactory{
+	  /**
+	   * Creates a new </code>{@link ShouldNotHavePropertyKeys}</code>.
+	   * 
+	   * @param actual the actual value in the failed assertion.
+	   * @param key the key used in the failed assertion to compare the actual property key to.
+	   * @return the created {@code ErrorMessageFactory}.
+	   */
+
+	  public static ErrorMessageFactory shouldNotHavePropertyKeys(Object actual, Iterable<String> key) {
+	    return new ShouldNotHavePropertyKeys(actual, key);
+	  }
+
+	  private ShouldNotHavePropertyKeys(Object actual, Iterable<String> other) {
+	    super("\nExpecting:\n  <%s>\n not to have property keys:\n  <%s>\n%s", actual, other, StandardComparisonStrategy
+	        .instance());
+	  }
+}

--- a/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_doesNotHavePropertyKeys_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_doesNotHavePropertyKeys_Test.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2013-2019 the original author or authors.
+ */
+package org.assertj.neo4j.api.indexdefinition;
+
+import static org.assertj.neo4j.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.graphdb.schema.IndexDefinition;
+
+public class IndexDefinitionAssert_doesNotHavePropertyKeys_Test {
+	  @Rule
+	  public ExpectedException expectedException = ExpectedException.none();
+
+	  private IndexDefinition indexDefinition = mock(IndexDefinition.class);
+	  
+	  @SuppressWarnings({ "unchecked", "rawtypes" })
+	  @Test
+	  public void should_pass_if_index_definition_does_not_have_expect_property_keys() {
+		  given_index_definition_with_property_keys("name","power");
+		  Collection list=new ArrayList<>();
+		  list.add("height");list.add("weight");
+		  assertThat(indexDefinition).doesNotHavePropertyKeys(list);	  
+	  }
+	  
+	  @SuppressWarnings({ "unchecked", "rawtypes" })
+	  @Test
+	  public void shoud_fail_if_index_definition_is_null() {
+		  expectedException.expect(AssertionError.class);
+		  expectedException.expectMessage("Expecting actual not to be null"); 
+		  Collection list=new ArrayList<>();
+		  list.add("height");list.add("weight");
+		  assertThat((IndexDefinition) null).doesNotHavePropertyKeys(list);
+	  }
+	  
+	  @SuppressWarnings({ "unchecked", "rawtypes" })
+	  @Test
+	  public void shoud_fail_if_index_definition_property_keys_null() {
+		  given_index_definition_with_property_keys("name","power");
+		  expectedException.expect(IllegalArgumentException.class);
+		  expectedException.expectMessage("The property keys to look for should not be null");	  
+		  assertThat(indexDefinition).doesNotHavePropertyKeys((Collection)null);
+	  }
+	  
+	  @SuppressWarnings({ "unchecked", "rawtypes" })
+	  @Test
+	  public void should_fail_if_index_definition_has_expect_property_keys() {
+		  given_index_definition_with_property_keys("name","power");
+		  expectedException.expect(AssertionError.class);
+		  Collection list=new ArrayList<>();
+		  list.add("name");list.add("power");
+		  assertThat(indexDefinition).doesNotHavePropertyKeys(list);  
+	  }
+	     
+	  @SuppressWarnings({ "unchecked", "rawtypes" })
+	  private void given_index_definition_with_property_keys(String... values) {
+		  Collection list=new ArrayList<>();
+		  for(String s: values) {
+			  list.add(s);
+		  }
+		  when(indexDefinition.getPropertyKeys()).thenReturn(list);
+	  }
+}

--- a/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_doesNotHavePropertyKeys_represnted_as_string_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_doesNotHavePropertyKeys_represnted_as_string_Test.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2013-2019 the original author or authors.
+ */
+package org.assertj.neo4j.api.indexdefinition;
+
+import static org.assertj.neo4j.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.graphdb.schema.IndexDefinition;
+
+
+public class IndexDefinitionAssert_doesNotHavePropertyKeys_represnted_as_string_Test {
+	  @Rule
+	  public ExpectedException expectedException = ExpectedException.none();
+
+	  private IndexDefinition indexDefinition = mock(IndexDefinition.class);
+	  
+	  @Test
+	  public void should_pass_if_index_definition_does_not_have_expect_property_keys_as_string() {
+		  given_index_definition_with_property_keys("name","power");
+		  assertThat(indexDefinition).doesNotHavePropertyKeys("height","weight");	  
+	  }
+	  
+	  @Test
+	  public void shoud_fail_if_index_definition_is_null() {
+		  expectedException.expect(AssertionError.class);
+		  expectedException.expectMessage("Expecting actual not to be null"); 
+		  assertThat((IndexDefinition) null).doesNotHavePropertyKeys("height","weight");
+	  }
+	  
+	  @Test
+	  public void shoud_fail_if_index_definition_property_keys_null() {
+		  given_index_definition_with_property_keys("name","power");
+		  expectedException.expect(IllegalArgumentException.class);
+		  expectedException.expectMessage("The property keys names to look for should not be null");	  
+		  assertThat(indexDefinition).doesNotHavePropertyKeys((String[])null);
+	  }
+	  
+	  @Test
+	  public void should_fail_if_index_definition_has_expect_property_keys_as_string() {
+		  given_index_definition_with_property_keys("name","power");
+		  expectedException.expect(AssertionError.class);
+		  assertThat(indexDefinition).doesNotHavePropertyKeys("name","power");  
+	  }
+	     
+	  @SuppressWarnings({ "unchecked", "rawtypes" })
+	  private void given_index_definition_with_property_keys(String... values) {
+		  Collection list=new ArrayList<>();
+		  for(String s: values) {
+			  list.add(s);
+		  }
+		  when(indexDefinition.getPropertyKeys()).thenReturn(list);
+	  }
+}

--- a/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_hasPropertyKeys_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_hasPropertyKeys_Test.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2013-2019 the original author or authors.
+ */
+package org.assertj.neo4j.api.indexdefinition;
+
+import static org.assertj.neo4j.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.graphdb.schema.IndexDefinition;
+
+
+
+public class IndexDefinitionAssert_hasPropertyKeys_Test {
+	  @Rule
+	  public ExpectedException expectedException = ExpectedException.none();
+
+	  private IndexDefinition indexDefinition = mock(IndexDefinition.class);
+	  
+	  @SuppressWarnings({ "unchecked", "rawtypes" })
+	  @Test
+	  public void should_pass_if_index_definition_has_property_keys() {
+		  given_index_definition_with_property_keys("name","power");
+		  Collection list=new ArrayList<>();
+		  list.add("name");list.add("power");
+		  assertThat(indexDefinition).hasPropertyKeys(list);	  
+	  }
+	  
+	  @SuppressWarnings({ "unchecked", "rawtypes" })
+	  @Test
+	  public void shoud_fail_if_index_definition_is_null() {
+		  expectedException.expect(AssertionError.class);
+		  expectedException.expectMessage("Expecting actual not to be null"); 
+		  Collection list=new ArrayList<>();
+		  list.add("name");list.add("power");
+		  assertThat((IndexDefinition) null).hasPropertyKeys(list);
+	  }
+	  
+	  @SuppressWarnings({ "unchecked", "rawtypes" })
+	  @Test
+	  public void shoud_fail_if_index_definition_property_keys_null() {
+		  given_index_definition_with_property_keys("name","power");
+		  expectedException.expect(IllegalArgumentException.class);
+		  expectedException.expectMessage("The property keys to look for should not be null");	  
+		  assertThat(indexDefinition).hasPropertyKeys((Collection)null);
+	  }
+	  
+	  @SuppressWarnings({ "unchecked", "rawtypes" })
+	  @Test
+	  public void should_fail_if_index_definition_has_not_expect_property_keys() {
+		  given_index_definition_with_property_keys("name","power");
+		  expectedException.expect(AssertionError.class);
+		  Collection list=new ArrayList<>();
+		  list.add("name");list.add("height");
+		  assertThat(indexDefinition).hasPropertyKeys(list);  
+	  }
+	     
+	  @SuppressWarnings({ "unchecked", "rawtypes" })
+	  private void given_index_definition_with_property_keys(String... values) {
+		  Collection list=new ArrayList<>();
+		  for(String s: values) {
+			  list.add(s);
+		  }
+		  when(indexDefinition.getPropertyKeys()).thenReturn(list);
+	  }
+}

--- a/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_hasPropertyKeys_represented_as_string_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/indexdefinition/IndexDefinitionAssert_hasPropertyKeys_represented_as_string_Test.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2013-2019 the original author or authors.
+ */
+package org.assertj.neo4j.api.indexdefinition;
+
+import static org.assertj.neo4j.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.graphdb.schema.IndexDefinition;
+
+
+
+public class IndexDefinitionAssert_hasPropertyKeys_represented_as_string_Test {
+	  @Rule
+	  public ExpectedException expectedException = ExpectedException.none();
+
+	  private IndexDefinition indexDefinition = mock(IndexDefinition.class);
+
+	  @Test
+	  public void should_pass_if_index_definition_has_property_keys() {
+		  given_index_definition_with_property_keys("name","power");
+		  assertThat(indexDefinition).hasPropertyKeys("name","power");	  
+	  }
+	  
+	  @Test
+	  public void shoud_fail_if_index_definition_is_null() {
+		  expectedException.expect(AssertionError.class);
+		  expectedException.expectMessage("Expecting actual not to be null"); 
+		  assertThat((IndexDefinition) null).hasPropertyKeys("name","power");
+	  }
+	  
+	  @Test
+	  public void shoud_fail_if_index_definition_property_keys_null() {
+		  given_index_definition_with_property_keys("name","power");
+		  expectedException.expect(IllegalArgumentException.class);
+		  expectedException.expectMessage("The property keys names to look for should not be null"); 
+		  assertThat(indexDefinition).hasPropertyKeys((String[])null);
+	  }
+	  
+	  @Test
+	  public void should_pass_if_index_definition_has_not_expect_property_keys() {
+		  given_index_definition_with_property_keys("name","power");
+		  expectedException.expect(AssertionError.class);
+		  assertThat(indexDefinition).hasPropertyKeys("name","height");  
+	  }
+	     
+	  @SuppressWarnings({ "unchecked", "rawtypes" })
+	  private void given_index_definition_with_property_keys(String... values) {
+		  Collection list=new ArrayList<>();
+		  for(String s: values) {
+			  list.add(s);
+		  }
+		  when(indexDefinition.getPropertyKeys()).thenReturn(list);
+	  }
+}


### PR DESCRIPTION
Added following methods in IndexDefinitionAssert with respective test cases:
-> hasPropertyKeys for String...
 ->hasPropertyKeys for Iterable<String>
 ->doesNotHavePropertyKeys for String...
 ->doesNotHavePropertyKeys for Iterable<String>