### PR TITLE
Provide assertions for ConstraintDefinition(propertyKeys)

### DIFF
--- a/src/main/java/org/assertj/neo4j/api/ConstraintDefinitionAssert.java
+++ b/src/main/java/org/assertj/neo4j/api/ConstraintDefinitionAssert.java
@@ -22,9 +22,15 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
+import org.neo4j.graphdb.schema.IndexDefinition;
 
 import static org.assertj.neo4j.error.ShouldHaveLabel.shouldHaveLabel;
+import static org.assertj.neo4j.error.ShouldHavePropertyKeys.shouldHavePropertyKeys;
 import static org.assertj.neo4j.error.ShouldNotHaveLabel.shouldNotHaveLabel;
+import static org.assertj.neo4j.error.ShouldNotHavePropertyKeys.shouldNotHavePropertyKeys;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Assertions for Neo4J {@link ConstraintDefinition}
@@ -344,4 +350,162 @@ public class ConstraintDefinitionAssert extends AbstractAssert<ConstraintDefinit
 
     return this;
   }
+  
+  /**
+   * Verifies that the actual {@link ConstraintDefinition} has the given set of property keys<br/>
+   * <p>
+   * Example:
+   *
+   * <pre>
+   * GraphDatabaseService graph = new TestGraphDatabaseFactory().newImpermanentDatabase();
+   * ConstraintDefinition constraintDefinition = graph.schema()
+   *    .constraintFor(&quot;User&quot;)
+   *    .assertPropertyIsUnique(&quot;Login&quot;)
+   *    .assertPropertyIsUnique(&quot;Username&quot;)
+   *    .create();
+   *    
+   * assertThat(constraintDefinition).hasPropertyKeys(&quot;Login&quot;,&quot;Username&quot;);
+   * </pre>
+   *
+   * If the <code>propertyKeysNames</code> is {@code null}, an {@link IllegalArgumentException} is thrown.
+   * <p>
+   *
+   * @param propertyKeys the list of property keys to look for in the actual {@link ConstraintDefinition}
+   * @return this {@link ConstraintDefinitionAssert} for assertions chaining
+   *
+   * @throws IllegalArgumentException if <code>propertyKeysNames</code> is {@code null}.
+   * @throws AssertionError if the actual {@link ConstraintDefinition} does not contain the given propertyKeys
+   */
+  public ConstraintDefinitionAssert hasPropertyKeys(String... propertyKeys) {
+    Objects.instance().assertNotNull(info, actual);
+
+    if (propertyKeys == null) {
+      throw new IllegalArgumentException("The property keys to look for should not be null");
+    }
+    return checkPropertyKeyPresence(Arrays.asList(propertyKeys));
+  }
+
+  /**
+   * Verifies that the actual {@link ConstraintDefinition} has the given set of property keys<br/>
+   * <p>
+   * Example:
+   *
+   * <pre>
+   * GraphDatabaseService graph = new TestGraphDatabaseFactory().newImpermanentDatabase();
+   * ConstraintDefinition constraintDefinition = graph.schema()
+   *    .constraintFor(&quot;User&quot;)
+   *    .assertPropertyIsUnique(&quot;Login&quot;)
+   *    .assertPropertyIsUnique(&quot;Username&quot;)
+   *    .create();
+   *
+   * assertThat(constraintDefinition).hasPropertyKeys(Arrays.asList(&quot;Username&quot;, &quot;Login&quot;));
+   * </pre>
+   *
+   * If the <code>propertyKeys</code> is {@code null}, an {@link IllegalArgumentException} is thrown.
+   * <p>
+   *
+   * @param propertyKeys the list of property keys to look for in the actual {@link ConstraintDefinition}
+   * @return this {@link ConstraintDefinitionAssert} for assertions chaining
+   *
+   * @throws IllegalArgumentException if <code>propertyKeys</code> is {@code null}.
+   * @throws AssertionError if the actual {@link ConstraintDefinition} does not contain the given propertyKeys
+   */
+  public ConstraintDefinitionAssert hasPropertyKeys(Iterable<String> propertyKeys) {
+    Objects.instance().assertNotNull(info, actual);
+
+    if (propertyKeys == null) {
+      throw new IllegalArgumentException("The property keys to look for should not be null");
+    }
+
+    return checkPropertyKeyPresence(propertyKeys);
+  }
+
+  /**
+   * Verifies that the actual {@link ConstraintDefinition} does NOT have the given set of property keys<br/>
+   * <p>
+   * Example:
+   *
+   * <pre>
+   * GraphDatabaseService graph = new TestGraphDatabaseFactory().newImpermanentDatabase();
+   * ConstraintDefinition constraintDefinition = graph.schema()
+   *    .constraintFor(&quot;User&quot;)
+   *    .assertPropertyIsUnique(&quot;Login&quot;)
+   *    .assertPropertyIsUnique(&quot;Username&quot;)
+   *    .create();
+   *
+   * assertThat(indexDefinition)
+   *    .doesNotHavePropertyKeys(&quot;dob&quot;, &quot;password&quot;);
+   * </pre>
+   *
+   * If the <code>propertyKeysNames</code> is {@code null}, an {@link IllegalArgumentException} is thrown.
+   * <p>
+   *
+   * @param propertyKeys the list of property keys to look for in the actual {@link ConstraintDefinition}
+   * @return this {@link ConstraintDefinitionAssert} for assertions chaining
+   *
+   * @throws IllegalArgumentException if <code>propertyKeysNames</code> is {@code null}.
+   * @throws AssertionError if the actual {@link ConstraintDefinition} does contain the given propertyKeys
+   */
+  public ConstraintDefinitionAssert doesNotHavePropertyKeys(String... propertyKeys) {
+    Objects.instance().assertNotNull(info, actual);
+
+    if (propertyKeys == null) {
+      throw new IllegalArgumentException("The property keys to look for should not be null");
+    }
+
+    return checkPropertyKeyAbsence(Arrays.asList(propertyKeys));
+  }
+
+  /**
+   * Verifies that the actual {@link ConstraintDefinition} does NOT have the given set of property keys<br/>
+   * <p>
+   * Example:
+   *
+   * <pre>
+   * GraphDatabaseService graph = new TestGraphDatabaseFactory().newImpermanentDatabase();
+   * ConstraintDefinition constraintDefinition = graph.schema()
+   *    .constraintFor(&quot;User&quot;)
+   *    .assertPropertyIsUnique(&quot;Login&quot;)
+   *    .assertPropertyIsUnique(&quot;Username&quot;)
+   *    .create();
+   *
+   * assertThat(indexDefinition)
+   *    .doesNotHavePropertyKeys(Arrays.asList(&quot;dob&quot;, &quot;password&quot;));
+   * </pre>
+   *
+   * If the <code>propertyKeys</code> is {@code null}, an {@link IllegalArgumentException} is thrown.
+   * <p>
+   *
+   * @param propertyKeys the list of property keys to look for in the actual {@link ConstraintDefinition}
+   * @return this {@link ConstraintDefinitionAssert} for assertions chaining
+   *
+   * @throws IllegalArgumentException if <code>propertyKeys</code> is {@code null}.
+   * @throws AssertionError if the actual {@link ConstraintDefinition} does contain the given propertyKeys
+   */
+  public ConstraintDefinitionAssert doesNotHavePropertyKeys(Iterable<String> propertyKeys) {
+    Objects.instance().assertNotNull(info, actual);
+
+    if (propertyKeys == null) {
+      throw new IllegalArgumentException("The property keys to look for should not be null");
+    }
+
+    return checkPropertyKeyAbsence(propertyKeys);
+  }
+
+  private ConstraintDefinitionAssert checkPropertyKeyPresence(Iterable<String> propertyKeys) {
+    List<String> missingPropertyKeys = Iterables.difference(propertyKeys, actual.getPropertyKeys());
+    if (missingPropertyKeys.size() > 0) {
+      throw Failures.instance().failure(info, shouldHavePropertyKeys(actual, propertyKeys, missingPropertyKeys));
+    }
+    return this;
+  }
+
+  private ConstraintDefinitionAssert checkPropertyKeyAbsence(Iterable<String> propertyKeys) {
+    List<String> commonPropertyKeys = Iterables.intersection(propertyKeys, actual.getPropertyKeys());
+    if (commonPropertyKeys.size() > 0) {
+      throw Failures.instance().failure(info, shouldNotHavePropertyKeys(actual, propertyKeys, commonPropertyKeys));
+    }
+    return this;
+  }
+
 }

--- a/src/test/java/org/assertj/neo4j/api/constraintdefinition/ConstraintDefinitionAssert_doesNotHavePropertyKeys_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/constraintdefinition/ConstraintDefinitionAssert_doesNotHavePropertyKeys_Test.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2013-2020 the original author or authors.
+ */
+package org.assertj.neo4j.api.constraintdefinition;
+
+import org.assertj.neo4j.api.ConstraintDefinitionAssert;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+
+import java.util.Arrays;
+
+import static org.assertj.neo4j.api.Assertions.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConstraintDefinitionAssert_doesNotHavePropertyKeys_Test {
+	private final ConstraintDefinition constraintDefinition = mock(ConstraintDefinition.class);
+	  @Rule
+	  public ExpectedException expectedException = ExpectedException.none();
+
+	  @Test
+	  public void should_pass_if_constraint_definition_does_not_have_expected_iterable_property_keys() {
+	    given_constraint_definition_with_property_keys("username", "dob");
+
+	    Assert.assertThat(assertThat(constraintDefinition).doesNotHavePropertyKeys(Arrays.asList("height", "weight")), instanceOf(
+	      ConstraintDefinitionAssert.class));
+	  }
+
+	  @Test
+	  public void should_pass_if_constraint_definition_does_not_have_expected_varargs_property_keys() {
+	    given_constraint_definition_with_property_keys("username", "dob");
+
+	    Assert.assertThat(assertThat(constraintDefinition).doesNotHavePropertyKeys("height", "weight"), instanceOf(
+	      ConstraintDefinitionAssert.class));
+	  }
+
+	  @Test
+	  public void should_fail_if_constraint_definition_is_null() {
+	    expectedException.expect(AssertionError.class);
+	    expectedException.expectMessage("Expecting actual not to be null");
+
+	    assertThat((ConstraintDefinition) null).doesNotHavePropertyKeys(Arrays.asList("height", "weight"));
+	  }
+
+	  @Test
+	  public void should_fail_if_expected_iterable_property_keys_are_null() {
+	    given_constraint_definition_with_property_keys("username", "dob");
+	    expectedException.expect(IllegalArgumentException.class);
+	    expectedException.expectMessage("The property keys to look for should not be null");
+
+	    assertThat(constraintDefinition).doesNotHavePropertyKeys((Iterable<String>) null);
+	  }
+
+	  @Test
+	  public void should_fail_if_expected_varargs_property_keys_are_null() {
+	    given_constraint_definition_with_property_keys("username", "dob");
+	    expectedException.expect(IllegalArgumentException.class);
+	    expectedException.expectMessage("The property keys to look for should not be null");
+
+	    assertThat(constraintDefinition).doesNotHavePropertyKeys((String[]) null);
+	  }
+
+	  @Test
+	  public void should_fail_if_constraint_definition_has_any_of_expected_iterable_property_keys() {
+	    given_constraint_definition_with_property_keys("username", "dob");
+	    expectedException.expect(AssertionError.class);
+
+	    assertThat(constraintDefinition).doesNotHavePropertyKeys(Arrays.asList("username", "password"));
+	  }
+
+	  @Test
+	  public void should_fail_if_constraint_definition_has_any_of_expected_varargs_property_keys() {
+	    given_constraint_definition_with_property_keys("username", "dob");
+	    expectedException.expect(AssertionError.class);
+
+	    assertThat(constraintDefinition).doesNotHavePropertyKeys("username", "password");
+	  }
+
+	  private void given_constraint_definition_with_property_keys(String... values) {
+	    when(constraintDefinition.getPropertyKeys()).thenReturn(Arrays.asList(values));
+	  }
+
+}

--- a/src/test/java/org/assertj/neo4j/api/constraintdefinition/ConstraintDefinitionAssert_hasPropertyKeys_Test.java
+++ b/src/test/java/org/assertj/neo4j/api/constraintdefinition/ConstraintDefinitionAssert_hasPropertyKeys_Test.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2013-2020 the original author or authors.
+ */
+package org.assertj.neo4j.api.constraintdefinition;
+
+import org.assertj.neo4j.api.ConstraintDefinitionAssert;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+
+import java.util.Arrays;
+
+import static org.assertj.neo4j.api.Assertions.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+public class ConstraintDefinitionAssert_hasPropertyKeys_Test {
+	
+	  private final ConstraintDefinition constraintDefinition = mock(ConstraintDefinition.class);
+	  @Rule
+	  public ExpectedException expectedException = ExpectedException.none();
+
+	  @Test
+	  public void should_pass_if_constraint_definition_has_iterable_property_keys() {
+	    given_constraint_definition_with_property_keys("username", "dob");
+
+	    Assert.assertThat(assertThat(constraintDefinition).hasPropertyKeys(Arrays.asList("username", "dob")), instanceOf(
+	      ConstraintDefinitionAssert.class));
+	  }
+
+	  @Test
+	  public void should_pass_if_constraint_definition_has_varargs_property_keys() {
+	    given_constraint_definition_with_property_keys("username", "dob");
+
+	    Assert.assertThat(assertThat(constraintDefinition).hasPropertyKeys("username", "dob"), instanceOf(
+	      ConstraintDefinitionAssert.class));
+	  }
+
+	  @Test
+	  public void should_fail_if_constraint_definition_is_null() {
+	    expectedException.expect(AssertionError.class);
+	    expectedException.expectMessage("Expecting actual not to be null");
+
+	    assertThat((ConstraintDefinition) null).hasPropertyKeys(Arrays.asList("username", "dob"));
+	  }
+
+	  @Test
+	  public void should_fail_if_constraint_definition_expected_iterable_property_keys_are_null() {
+	    given_constraint_definition_with_property_keys("username", "dob");
+	    expectedException.expect(IllegalArgumentException.class);
+	    expectedException.expectMessage("The property keys to look for should not be null");
+
+	    assertThat(constraintDefinition).hasPropertyKeys((Iterable<String>) null);
+	  }
+
+	  @Test
+	  public void should_fail_if_constraint_expected_varargs_property_keys_are_null() {
+	    given_constraint_definition_with_property_keys("username", "dob");
+	    expectedException.expect(IllegalArgumentException.class);
+	    expectedException.expectMessage("The property keys to look for should not be null");
+
+	    assertThat(constraintDefinition).hasPropertyKeys((String[]) null);
+	  }
+
+	  @Test
+	  public void should_fail_if_constraint_definition_does_not_have_all_expected_iterable_property_keys() {
+	    given_constraint_definition_with_property_keys("username", "dob");
+	    expectedException.expect(AssertionError.class);
+
+	    assertThat(constraintDefinition).hasPropertyKeys(Arrays.asList("username", "password"));
+	  }
+
+	  @Test
+	  public void should_fail_if_constraint_definition_does_not_have_all_expected_varargs_property_keys() {
+	    given_constraint_definition_with_property_keys("username", "dob");
+	    expectedException.expect(AssertionError.class);
+
+	    assertThat(constraintDefinition).hasPropertyKeys("username", "password");
+	  }
+
+	  private void given_constraint_definition_with_property_keys(String... values) {
+	    when(constraintDefinition.getPropertyKeys()).thenReturn(Arrays.asList(values));
+	  }
+
+}


### PR DESCRIPTION
Following methods are added in the ConstraintDefinitionAssert class:
->  hasPropertyKeys for String...
 ->hasPropertyKeys for Iterable<String>
 ->doesNotHavePropertyKeys for String...
 ->doesNotHavePropertyKeys for Iterable<String>